### PR TITLE
Add getter method to access protected regions property

### DIFF
--- a/src/Region.php
+++ b/src/Region.php
@@ -128,4 +128,12 @@ class Region
     {
         return $this->locale;
     }
+    
+    /**
+     * @return array
+     */
+    public static function getRegions()
+    {
+        return static::$regions;
+    }
 }


### PR DESCRIPTION
Access to all possible/valid regions before instantiation. To prevent duplicate region definitions. Ex:
- Fill a dropdown select box with all regions.
- Region validation without instantiation of `Region`. 

Also, consider using custom exceptions in the constructor to simplefy detecting what parameter was actually wrong.
Use case ex: wanting to transform it to localized error messages. Currently requires to:
```php
$regionStr = 'eu';
$locale = 'en_GB';
try {
    $region = new Region($regionStr, $locale)
}
catch (\InvalidArgumentException $e) {
        if(strpos($e->getMessage(), 'not a valid region') !== false){
            translate('invalid_region'); // random translate function
        } else {
            translate('invalid_locale')
        }
}
```

