### PR TITLE
Added Accept-Encoding "gzip" to Guzzle header options

### DIFF
--- a/src/Core/AbstractClient.php
+++ b/src/Core/AbstractClient.php
@@ -182,6 +182,7 @@ abstract class AbstractClient
         $options = array_replace_recursive($options, [
             'headers' => [
                 'Accept'     => 'application/json',
+                'Accept-Encoding' => 'gzip',
                 'User-Agent' => $this->getUserAgent(),
             ],
             'query' => [


### PR DESCRIPTION
This greatly increases speed of the extremely large JSON data feeds from Blizzard's Auction API.  In my tests it dropped the delay from 8-9 seconds down to less than 2 seconds.