### PR TITLE
Improve class and race information on CharacterEntity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 vendor
-bin
 coverage
 coverage.xml
 composer.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ install:
   - travis_retry composer update $COMPOSER_OPTS
 
 script:
-  - bin/phpunit --coverage-text --coverage-clover coverage.xml
+  - vendor/bin/phpunit --coverage-text --coverage-clover coverage.xml
 
 after_script:
   - wget https://scrutinizer-ci.com/ocular.phar

--- a/composer.json
+++ b/composer.json
@@ -36,9 +36,6 @@
             "Pwnraid\\Bnet\\Test\\": "test"
         }
     },
-    "config": {
-        "bin-dir": "bin"
-    },
     "extra": {
         "branch-alias": {
             "dev-master": "1.0-dev"

--- a/src/Exceptions/InvalidClassException.php
+++ b/src/Exceptions/InvalidClassException.php
@@ -1,0 +1,7 @@
+<?php
+namespace Pwnraid\Bnet\Exceptions;
+
+class InvalidClassException extends \Exception
+{
+
+}

--- a/src/Exceptions/InvalidRaceException.php
+++ b/src/Exceptions/InvalidRaceException.php
@@ -1,0 +1,7 @@
+<?php
+namespace Pwnraid\Bnet\Exceptions;
+
+class InvalidRaceException extends \Exception
+{
+
+}

--- a/src/Warcraft/Characters/CharacterEntity.php
+++ b/src/Warcraft/Characters/CharacterEntity.php
@@ -10,6 +10,14 @@ class CharacterEntity extends AbstractEntity
     {
         parent::__construct($body);
 
+        if (array_key_exists('class', $this->attributes) === true) {
+            $this->attributes['class'] = ClassEntity::fromId($this->attributes['class']);
+        }
+
+        if (array_key_exists('race', $this->attributes) === true) {
+            $this->attributes['race'] = RaceEntity::fromId($this->attributes['race']);
+        }
+
         if (array_key_exists('thumbnail', $this->attributes) === true) {
             $this->attributes['id'] = Utils::thumbnailToId($this->attributes['thumbnail']);
         }

--- a/src/Warcraft/Characters/ClassEntity.php
+++ b/src/Warcraft/Characters/ClassEntity.php
@@ -2,7 +2,85 @@
 namespace Pwnraid\Bnet\Warcraft\Characters;
 
 use Pwnraid\Bnet\Core\AbstractEntity;
+use Pwnraid\Bnet\Exceptions\InvalidClassException;
 
 class ClassEntity extends AbstractEntity
 {
+    protected static $classes = [
+        1 => [
+            'id'        => 1,
+            'mask'      => 1,
+            'powerType' => 'rage',
+            'name'      => 'Warrior',
+        ],
+        2 => [
+            'id'        => 2,
+            'mask'      => 2,
+            'powerType' => 'mana',
+            'name'      => 'Paladin',
+        ],
+        3 => [
+            'id'        => 3,
+            'mask'      => 4,
+            'powerType' => 'focus',
+            'name'      => 'Hunter',
+        ],
+        4 => [
+            'id'        => 4,
+            'mask'      => 8,
+            'powerType' => 'energy',
+            'name'      => 'Rogue',
+        ],
+        5 => [
+            'id'        => 5,
+            'mask'      => 16,
+            'powerType' => 'mana',
+            'name'      => 'Priest',
+        ],
+        6 => [
+            'id'        => 6,
+            'mask'      => 32,
+            'powerType' => 'runic-power',
+            'name'      => 'Death Knight',
+        ],
+        7 => [
+            'id'        => 7,
+            'mask'      => 64,
+            'powerType' => 'mana',
+            'name'      => 'Shaman',
+        ],
+        8 => [
+            'id'        => 8,
+            'mask'      => 128,
+            'powerType' => 'mana',
+            'name'      => 'Mage',
+        ],
+        9 => [
+            'id'        => 9,
+            'mask'      => 256,
+            'powerType' => 'mana',
+            'name'      => 'Warlock',
+        ],
+        10 => [
+            'id'        => 10,
+            'mask'      => 512,
+            'powerType' => 'energy',
+            'name'      => 'Monk',
+        ],
+        11 => [
+            'id'        => 11,
+            'mask'      => 1024,
+            'powerType' => 'mana',
+            'name'      => 'Druid',
+        ],
+    ];
+
+    public static function fromId($classId)
+    {
+        if (isset(static::$classes[$classId]) === false) {
+            throw new InvalidClassException('Unknown class with ID #'.$classId);
+        }
+
+        return new static(static::$classes[$classId]);
+    }
 }

--- a/src/Warcraft/Characters/RaceEntity.php
+++ b/src/Warcraft/Characters/RaceEntity.php
@@ -2,7 +2,124 @@
 namespace Pwnraid\Bnet\Warcraft\Characters;
 
 use Pwnraid\Bnet\Core\AbstractEntity;
+use Pwnraid\Bnet\Exceptions\InvalidRaceException;
 
 class RaceEntity extends AbstractEntity
 {
+    protected static $races = [
+        1 => [
+            'id'   => 1,
+            'mask' => 1,
+            'side' => 'alliance',
+            'name' => 'Human',
+
+        ],
+        2 => [
+            'id'   => 2,
+            'mask' => 2,
+            'side' => 'horde',
+            'name' => 'Orc',
+
+        ],
+        3 => [
+            'id'   => 3,
+            'mask' => 4,
+            'side' => 'alliance',
+            'name' => 'Dwarf',
+
+        ],
+        4 => [
+            'id'   => 4,
+            'mask' => 8,
+            'side' => 'alliance',
+            'name' => 'Night Elf',
+
+        ],
+        5 => [
+            'id'   => 5,
+            'mask' => 16,
+            'side' => 'horde',
+            'name' => 'Undead',
+
+        ],
+        6 => [
+            'id'   => 6,
+            'mask' => 32,
+            'side' => 'horde',
+            'name' => 'Tauren',
+
+        ],
+        7 => [
+            'id'   => 7,
+            'mask' => 64,
+            'side' => 'alliance',
+            'name' => 'Gnome',
+
+        ],
+        8 => [
+            'id'   => 8,
+            'mask' => 128,
+            'side' => 'horde',
+            'name' => 'Troll',
+
+        ],
+        9 => [
+            'id'   => 9,
+            'mask' => 256,
+            'side' => 'horde',
+            'name' => 'Goblin',
+        ],
+        10 => [
+            'id'   => 10,
+            'mask' => 512,
+            'side' => 'horde',
+            'name' => 'Blood Elf',
+
+        ],
+        11 => [
+            'id'   => 11,
+            'mask' => 1024,
+            'side' => 'alliance',
+            'name' => 'Draenei',
+
+        ],
+        22 => [
+            'id'   => 22,
+            'mask' => 2097152,
+            'side' => 'alliance',
+            'name' => 'Worgen',
+
+        ],
+        24 => [
+            'id'   => 24,
+            'mask' => 8388608,
+            'side' => 'neutral',
+            'name' => 'Pandaren',
+
+        ],
+        25 => [
+            'id'   => 25,
+            'mask' => 16777216,
+            'side' => 'alliance',
+            'name' => 'Pandaren',
+
+        ],
+        26 => [
+            'id'   => 26,
+            'mask' => 33554432,
+            'side' => 'horde',
+            'name' => 'Pandaren',
+
+        ],
+    ];
+
+    public static function fromId($raceId)
+    {
+        if (isset(static::$races[$raceId]) === false) {
+            throw new InvalidRaceException('Unknown race with ID #'.$raceId);
+        }
+
+        return new static(static::$races[$raceId]);
+    }
+
 }

--- a/test/Warcraft/Characters/CharacterEntityTest.php
+++ b/test/Warcraft/Characters/CharacterEntityTest.php
@@ -1,7 +1,8 @@
 <?php
 namespace Pwnraid\Bnet\Test\Warcraft\Characters;
 
-use Pwnraid\Bnet\Warcraft\Characters\CharacterEntity;
+use Pwnraid\Bnet\Warcraft\Characters;
+
 
 class CharacterEntityTest extends \PHPUnit_Framework_TestCase
 {
@@ -21,9 +22,18 @@ class CharacterEntityTest extends \PHPUnit_Framework_TestCase
         parent::tearDown();
     }
 
+    public function testClassAttribute()
+    {
+        $character = new Characters\CharacterEntity([
+            'class' => 1,
+        ]);
+
+        $this->assertInstanceOf(Characters\ClassEntity::class, $character->class);
+    }
+
     public function testIdAttribute()
     {
-        $character = new CharacterEntity([
+        $character = new Characters\CharacterEntity([
             'thumbnail' => 'auchindoun/222/82213342-avatar.jpg',
         ]);
 
@@ -33,11 +43,20 @@ class CharacterEntityTest extends \PHPUnit_Framework_TestCase
     public function testLastModifiedAttribute()
     {
         $timestamp = time();
-        $character = new CharacterEntity([
+        $character = new Characters\CharacterEntity([
             'lastModified' => ($timestamp * 1000),
         ]);
 
         $this->assertInstanceOf('DateTime', $character->lastModified);
         $this->assertSame(date('Y-m-d H:i:s', $timestamp), $character->lastModified->format('Y-m-d H:i:s'));
+    }
+
+    public function testRaceAttribute()
+    {
+        $character = new Characters\CharacterEntity([
+            'race' => 1,
+        ]);
+
+        $this->assertInstanceOf(Characters\RaceEntity::class, $character->race);
     }
 }

--- a/test/Warcraft/Characters/ClassEntityTest.php
+++ b/test/Warcraft/Characters/ClassEntityTest.php
@@ -1,0 +1,23 @@
+<?php
+namespace Pwnraid\Bnet\Test\Warcraft\Characters;
+
+use Pwnraid\Bnet\Warcraft\Characters\ClassEntity;
+
+
+class ClassEntityTest extends \PHPUnit_Framework_TestCase
+{
+    public function testFromIdWithValidId()
+    {
+        $race = ClassEntity::fromId(1);
+
+        $this->assertInstanceOf(ClassEntity::class, $race);
+    }
+
+    /**
+     * @expectedException Pwnraid\Bnet\Exceptions\InvalidClassException
+     */
+    public function testFromIdWithInvalidId()
+    {
+        ClassEntity::fromId(123);
+    }
+}

--- a/test/Warcraft/Characters/RaceEntityTest.php
+++ b/test/Warcraft/Characters/RaceEntityTest.php
@@ -1,0 +1,23 @@
+<?php
+namespace Pwnraid\Bnet\Test\Warcraft\Characters;
+
+use Pwnraid\Bnet\Warcraft\Characters\RaceEntity;
+
+
+class RaceEntityTest extends \PHPUnit_Framework_TestCase
+{
+    public function testFromIdWithValidId()
+    {
+        $race = RaceEntity::fromId(1);
+
+        $this->assertInstanceOf(RaceEntity::class, $race);
+    }
+
+    /**
+     * @expectedException Pwnraid\Bnet\Exceptions\InvalidRaceException
+     */
+    public function testFromIdWithInvalidId()
+    {
+        RaceEntity::fromId(123);
+    }
+}


### PR DESCRIPTION
It would probably be useful to set class and race on `CharacterEntity` to a `ClassEntity` and `RaceEntity` respectively. Since this data rarely changes (only when new expansions are released.. so far!) we can just maintain this information as a static property within the entity itself and create an instance based on the ID of the character's class or race.