### PR TITLE
Add a default timeout to Guzzle requests

### DIFF
--- a/src/Core/AbstractClient.php
+++ b/src/Core/AbstractClient.php
@@ -191,7 +191,7 @@ abstract class AbstractClient
                 'apikey' => $this->apiKey,
                 'locale' => $this->region->getLocale(),
             ],
-			'timeout' => 60,
+            'timeout' => 60,
         ]);
 
         try {

--- a/src/Core/AbstractClient.php
+++ b/src/Core/AbstractClient.php
@@ -191,6 +191,7 @@ abstract class AbstractClient
                 'apikey' => $this->apiKey,
                 'locale' => $this->region->getLocale(),
             ],
+			'timeout' => 60,
         ]);
 
         try {


### PR DESCRIPTION
I added a 60 second default timeout to Guzzle requests.  In my experience the longest requests to Blizzard are for Auction data, and with gzip those take <10 seconds.  I believe 60 seconds to be an adequate default timeout in the event Blizzard servers never respond.