### PR TITLE
Update AbstractClient.php

### DIFF
--- a/src/Core/AbstractClient.php
+++ b/src/Core/AbstractClient.php
@@ -213,7 +213,7 @@ abstract class AbstractClient
                     return;
                 default:
                     $data = json_decode($exception->getResponse()->getBody(), true);
-                    throw new BattleNetException($data['reason'], $exception->getCode());
+                    throw new BattleNetException($data['detail'], $exception->getCode());
             }
         }
 


### PR DESCRIPTION
The reason seems to have been replaced with detail.

<sample>
array (
  'code' => 403,
  'type' => 'Forbidden',
  'detail' => 'Account Inactive',
)
</sample>